### PR TITLE
Halofit accelerated

### DIFF
--- a/src/LimberJack.jl
+++ b/src/LimberJack.jl
@@ -1,11 +1,11 @@
 module LimberJack
 
 export CosmoPar, Cosmology
-export Ez, Hmpc, comoving_radial_distance, power_spectrum, growth_factor
+export Ez, Hmpc, comoving_radial_distance, growth_factor
 export NumberCountsTracer, WeakLensingTracer, CMBLensingTracer, get_Fℓ
 export angularCℓ, lin_Pk, nonlin_Pk
 
-using Interpolations, QuadGK, OrdinaryDiffEq, Trapz, Roots, Zygote, ForwardDiff, LinearAlgebra
+using Interpolations, QuadGK, OrdinaryDiffEq, Trapz, ForwardDiff, LinearAlgebra
 
 include("core.jl")
 include("tracers.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -64,10 +64,8 @@ end
 
 Cosmology(cpar::CosmoPar; nk=256, nz=256, tk_mode="BBKS", Pk_mode="linear") = begin
     # Compute linear power spectrum at z=0.
-    lkmin = -4
-    lkmax = 2
-    logk = range(lkmin, stop=lkmax, length=nk)
-    ks = 10 .^ logk
+    logk = range(log(0.0001), stop=log(100.0), length=nk)
+    ks = exp.(logk)
     dlogk = log(ks[2]/ks[1])
     if tk_mode== "EisHu"
         tk = TkEisHu(cpar, ks./ cpar.h)

--- a/src/core.jl
+++ b/src/core.jl
@@ -113,6 +113,7 @@ Cosmology(cpar::CosmoPar; nk=256, nz=256, tk_mode="BBKS", Pk_mode="linear") = be
     Dzi = LinearInterpolation(zs, Dzs, extrapolation_bc=Line())
 
 
+    # OPT: separate zs for Pk and background
     if Pk_mode == "linear"
         # OPT: check order in line below and the reduce stuff
         Pks = [@. exp(pki(log(k)))*Dzi(zs)^2 for k in ks]

--- a/src/core.jl
+++ b/src/core.jl
@@ -45,7 +45,7 @@ end
 
 struct Cosmology
     cosmo::CosmoPar
-    # Powero spectrum
+    # Power spectrum
     ks::Array
     pk0::Array
     dlogk

--- a/src/core.jl
+++ b/src/core.jl
@@ -45,7 +45,7 @@ end
 
 struct Cosmology
     cosmo::CosmoPar
-    # Power spectrum
+    # Powero spectrum
     ks::Array
     pk0::Array
     dlogk
@@ -116,7 +116,7 @@ Cosmology(cpar::CosmoPar; nk=256, nz=256, tk_mode="BBKS", Pk_mode="linear") = be
     if Pk_mode == "linear"
         # OPT: check order in line below and the reduce stuff
         Pks = [@. exp(pki(log(k)))*Dzi(zs)^2 for k in ks]
-        Pks = reduce(vcat, transpose.(PkLs))
+        Pks = reduce(vcat, transpose.(Pks))
         # OPT: check order of this too
         Pk = LinearInterpolation((log.(ks), zs), log.(Pks))
     elseif Pk_mode == "Halofit"
@@ -124,9 +124,9 @@ Cosmology(cpar::CosmoPar; nk=256, nz=256, tk_mode="BBKS", Pk_mode="linear") = be
     else 
         # OPT: check order in line below and the reduce stuff
         Pks = [@. exp(pki(log(k)))*Dzi(zs)^2 for k in ks]
-        Pks = reduce(vcat, transpose.(PkLs))
+        Pks = reduce(vcat, transpose.(Pks))
         # OPT: check order of this too
-        Pk = LinearInterpolation((log.(ks), zs), log.(PkLs))
+        Pk = LinearInterpolation((log.(ks), zs), log.(Pks))
         print("Pk mode not implemented. Using linear Pk.")
     end
     Cosmology(cpar, ks, pk0, dlogk,

--- a/src/halofit.jl
+++ b/src/halofit.jl
@@ -21,13 +21,12 @@ function get_σ2(lks, ks, pks, R, kind)
     return trapz(lks, integrand)/(2*pi^2)
 end
 
-function get_PKnonlin(cosmo::CosmoPar, z, k, lPkLz0, Dz)
+function get_PKnonlin(cosmo::CosmoPar, z, k, PkLz0, Dzs)
     nk = length(k)
     nz = length(z)
     logk = log.(k)
 
-    PkLz0 = exp.(lPkLz0(logk))
-    Dz2s = Dz(z) .^ 2
+    Dz2s = Dzs .^ 2
     # OPT: hard-coded range and number of points
     lR0 = log(0.1)
     lR1 = log(10.0)

--- a/src/halofit.jl
+++ b/src/halofit.jl
@@ -5,18 +5,23 @@ halofit:
 - Date: 2021-09-17
 =#
 
-# OPT: do we need for this to be a structure?
-struct PKnonlin
-    a::Array
-    k::Array
-    rsig::AbstractInterpolation
-    sigma2::AbstractInterpolation
-    neff::AbstractInterpolation
-    C::AbstractInterpolation
-    pk_NL::AbstractInterpolation
+function get_σ2(ks, pks, R, kind)
+    lks = log.(ks)
+    k2 = ks .^ 2
+    k3 = k2 .* ks
+    x2 = @. (ks*R)^2
+    if kind == 2
+        pre = x2
+    elseif kind == 4
+        pre = @. x2*(1-x2)
+    else
+        pre = 1
+    end
+    integrand = @. k3 * pre * exp(-x2) * pks
+    return trapz(lks, integrand)/(2*pi^2)
 end
 
-PKnonlin(cosmo::CosmoPar, z, k, PkLs) = begin
+function get_PKnonlin(cosmo::CosmoPar, z, k, lPkLz0, Dz)
     nk = length(k)
     nz = length(z)
     logk = log.(k)
@@ -24,108 +29,42 @@ PKnonlin(cosmo::CosmoPar, z, k, PkLs) = begin
     zs = reverse(z)
     nk = length(k)
     nz = length(z)
-    # OPT: check order
-    PkL = reverse(transpose(PkLs), dims=1)
-    
-    rsigs =[get_rsigma(PkL[i, :], logk) for i in range(1, stop=nz)]
-    sigma2s = [rsigma_func(rsigs[i], PkL[i, :], logk) + 1 for i in range(1, stop=nz)]
-    onederiv_ints = [trapz(logk, onederiv_gauss_norm_int_func(logk, PkL[i, :], rsigs[i])) for i in range(1, stop=nz)]
-    neffs = @. -rsigs/sigma2s*onederiv_ints - 3.0
-    twoderiv_ints = [trapz(logk, twoderiv_gauss_norm_int_func(logk, PkL[i, :], rsigs[i])) for i in range(1, stop=nz)]
-    Cs = [-(rsigs[i]^2/sigma2s[i]*twoderiv_ints[i] - rsigs[i]^2/sigma2s[i]^2*onederiv_ints[i]^2
-          + rsigs[i]/sigma2s[i]*onederiv_ints[i]) for i in range(1, stop=nz)]
-    
-    # Interpolate linearily over a
-    rsig = LinearInterpolation(a, rsigs)
-    sigma2 = LinearInterpolation(a, sigma2s)
-    neff = LinearInterpolation(a, neffs)
-    C = LinearInterpolation(a, Cs)
 
-    pk_NLs = [power_spectrum_nonlin(cosmo, PkL[i, :], k, a[i], rsigs[i], sigma2s[i], neffs[i], Cs[i]) for i in range(1, stop=nz)]
+    PkLz0 = exp.(lPkLz0(log.(k)))
+    Dz2s = Dz(zs) .^ 2
+    lRs = range(log(0.1), stop=log(10.0), length=64)
+    lσ2s = log.([get_σ2(k, PkLz0, exp(lR), 0) for lR in lRs])
+    lσ2i = CubicSplineInterpolation(lRs, lσ2s)
+    rsigs = [get_rsigma(lσ2i, Dz2s[i], log(0.1), log(10.0)) for i in range(1, stop=nz)]
+
+    onederiv_ints = [get_σ2(k, PkLz0, rsigs[i], 2) * Dz2s[i] for i in range(1, stop=nz)]
+    twoderiv_ints = [get_σ2(k, PkLz0, rsigs[i], 4) * Dz2s[i] for i in range(1, stop=nz)]
+    neffs = @. 2*onederiv_ints - 3.0
+    Cs = @. 4*(twoderiv_ints + onederiv_ints^2)
+
+    # Interpolate linearily over a
+    pk_NLs = [power_spectrum_nonlin(cosmo, PkLz0 .* Dz2s[i], k, a[i], rsigs[i], neffs[i], Cs[i])
+              for i in range(1, stop=nz)]
     pk_NLs = reduce(vcat,transpose.(pk_NLs))
     pk_NLs = transpose(reverse(pk_NLs, dims=1))
-    pk_NL = LinearInterpolation((k, z), pk_NLs)
+    pk_NL = LinearInterpolation((log.(k), z), log.(pk_NLs))
 
-    PKnonlin(a, k, rsig, sigma2, neff, C, pk_NL)
+    return pk_NL
 end 
 
-function gauss_norm_int_func(logk, pk, R)
-    k = exp.(logk)
-    k2 = k .^ 2
-    integ = @. pk*k*k2/2.0/pi^2*exp(-k2*R^2)
-    return integ
+function get_rsigma(lσ2i, Dz2, lRmin, lRmax)
+    lDz2 = log(Dz2)
+    lRsigma = find_zero(lR -> lσ2i(lR)+lDz2, (lRmin, lRmax))
+    return exp(lRsigma)
 end
 
-function onederiv_gauss_norm_int_func(logk, pk, R)
-    k = exp.(logk)
-    k2 = k .^ 2
-    integ = @. (-2.0*R*k2)*pk*k*k2/2.0/pi^2*exp(-k2*R^2)
-    return integ
-end
-
-function twoderiv_gauss_norm_int_func(logk, pk, R)
-    k = exp.(logk)
-    k2 = k .^ 2
-    R2 = R .^ 2
-    integ = @. (-2.0*k2 + 4*k2^2*R2)*pk*k*k2/2.0/pi^2*exp(-k2*R2)
-    return integ
-end
-
-# function whose root is \sigma^2{rsigma, a} = 1
-function rsigma_func(rsigma, pk, logk)
-    result = trapz(logk, gauss_norm_int_func(logk, pk, rsigma)) - 1.0
-    return result
-end
-
-function solve_for_rsigma(pk, logk)
-    rlow = 1e-2
-    rhigh = 1e2
-#     f1 = rsig -> rsigma_func(rsig, pk, logk)
-#     f2 = rsig -> trapz(logk, onederiv_gauss_norm_int_func(logk, pk, rsig))
-#     rsigma = find_zero((f1, f2), 5.5, Roots.Newton())
-    rsigma = find_zero(rsig -> rsigma_func(rsig, pk, logk), (rlow, rhigh))
-    return rsigma
-end
-
-function solve_for_rsigma(pk::Vector{D}, logk) where D<:ForwardDiff.Dual
-    pk0 = ForwardDiff.value.(pk)
-    rsig0 = solve_for_rsigma(pk0, logk)
-    ∂pk = ForwardDiff.gradient(pkl -> rsigma_func(rsig0, pkl, logk), pk0)
-    ∂rsig = ForwardDiff.derivative(rsig -> rsigma_func(rsig, pk0, logk), rsig0)
-    parts_in = zip(collect.(ForwardDiff.partials.(pk))...)
-    parts_out = map(x->dot(-∂pk./∂rsig, x), parts_in)
-    # (parts_out...,) from vector to (*, *, *)
-    p = ForwardDiff.Partials((parts_out...,))
-    return D(rsig0, p)
-end
-
-function get_rsigma(pk, logk)
-    rlow = 1e-2
-    rhigh = 1e2
-    # we have to bound the root, otherwise return -1
-    # we will fiil in any -1's in the calling routine
-    flow = rsigma_func(rlow, pk, logk)
-    fhigh = rsigma_func(rhigh, pk, logk)
-
-    if flow * fhigh > 0
-        return -1
-    end
-
-    rsigma = solve_for_rsigma(pk, logk)
-
-    return rsigma
-end
-
-function power_spectrum_nonlin(cpar::CosmoPar, PkL, k, a, rsig, sigma2, neff, C)
-
-    zs = @. 1.0/a - 1.0
-    weffa = -1.0
-    Ez = @. sqrt(cpar.Ωm*(1+zs)^3+cpar.Ωr*(1+zs)^4+cpar.ΩΛ)
-    omegaMz = @. cpar.Ωm / (a^3) / Ez^2 
-    omegaDEwz = (1 - cpar.Ωm)/Ez^2
+function power_spectrum_nonlin(cpar::CosmoPar, PkL, k, a, rsig, neff, C)
+    zz = 1.0/a - 1.0
+    Ez2 = cpar.Ωm*(1+zz)^3+cpar.Ωr*(1+zz)^4+cpar.ΩΛ
+    omegaMz = cpar.Ωm*(1+zz)^3 / Ez2
+    omegaDEwz = cpar.ΩΛ/Ez2
 
     # not using these to match CLASS better - might be a bug in CLASS
-    # weffa = gsl_spline_eval(hf->weff, a, NULL);
     # omegaMz = gsl_spline_eval(hf->omeff, a, NULL);
     # omegaDEwz = gsl_spline_eval(hf->deeff, a, NULL);
 
@@ -136,21 +75,14 @@ function power_spectrum_nonlin(cpar::CosmoPar, PkL, k, a, rsig, sigma2, neff, C)
 
     delta2_norm = @. k*k*k/2.0/pi/pi
 
-    # compute the present day neutrino massive neutrino fraction
-    # uses all neutrinos even if they are moving fast
-#     om_nu = cosmo.sum_nu_masses / 93.14 / cosmo.h / cosmo.h
-#     fnu = om_nu / (cosmo.Ωm)
-    fnu = 0.0
-
     # eqns A6 - A13 of Takahashi et al.
     an = @. 10.0^(1.5222 + 2.8553*neff + 2.3706*neff2 + 0.9903*neff3 +
-        0.2250*neff4 - 0.6038*C + 0.1749*omegaDEwz*(1.0 + weffa))
-    bn = @. 10.0^(-0.5642 + 0.5864*neff + 0.5716*neff2 - 1.5474*C + 0.2279*omegaDEwz*(1.0 + weffa))
+        0.2250*neff4 - 0.6038*C)
+    bn = @. 10.0^(-0.5642 + 0.5864*neff + 0.5716*neff2 - 1.5474*C)
     cn = @. 10.0^(0.3698 + 2.0404*neff + 0.8161*neff2 + 0.5869*C)
     gamman = @. 0.1971 - 0.0843*neff + 0.8460*C
     alphan = @. abs(6.0835 + 1.3373*neff - 0.1959*neff2 - 5.5274*C)
     betan = @. 2.0379 - 0.7354*neff + 0.3157*neff2 + 1.2490*neff3 + 0.3980*neff4 - 0.1682*C
-    mun = 0.0
     nun = @. 10.0^(5.2105 + 3.6902*neff)
 
     # eqns C17 and C18 for Smith et al.
@@ -171,28 +103,16 @@ function power_spectrum_nonlin(cpar::CosmoPar, PkL, k, a, rsig, sigma2, neff, C)
         f3 = 1.0
     end
 
-    # correction to betan from Bird et al., eqn A10
-    betan += (fnu * (1.081 + 0.395*neff2))
-
     # eqns A1 - A3
     y = k ./ ksigma
     y2 = @. y * y
     fy = @. y/4.0 + y2/8.0
     DeltakL =  PkL .* delta2_norm
 
-    # correction to DeltakL from Bird et al., eqn A9
-    kh = @. k / cpar.h
-    kh2 = @. kh * kh
-    DeltakL_tilde_fac = @. fnu * (47.48 * kh2) / (1.0 + 1.5 * kh2)
-    DeltakL_tilde = @. DeltakL * (1.0 + DeltakL_tilde_fac)
-    DeltakQ = @. DeltakL * (1.0 + DeltakL_tilde)^betan / (1.0 + DeltakL_tilde*alphan) * exp(-fy)
+    DeltakQ = @. DeltakL * (1.0 + DeltakL)^betan / (1.0 + DeltakL*alphan) * exp(-fy)
 
     DeltakHprime = @. an * y^(3.0*f1) / (1.0 + bn*y^f2 + (cn*f3*y)^(3.0 - gamman))
-    DeltakH = @. DeltakHprime / (1.0 + mun/y + nun/y2)
-
-    # correction to DeltakH from Bird et al., eqn A6-A7
-    Qnu = @. fnu * (0.977 - 18.015 * (cpar.Ωm - 0.3))
-    DeltakH *= @. (1.0 + Qnu)
+    DeltakH = @. DeltakHprime / (1.0 + nun/y2)
 
     DeltakNL = @. DeltakQ + DeltakH
     PkNL = @. DeltakNL / delta2_norm

--- a/src/spectra.jl
+++ b/src/spectra.jl
@@ -11,7 +11,7 @@ function Cℓintegrand(cosmo::Cosmology,
     z = cosmo.z_of_chi(chi)
     w1 = t1.wint(chi)*t1.bias
     w2 = t2.wint(chi)*t2.bias
-    pk = cosmo.Pk(k, z)
+    pk = nonlin_Pk(cosmo, k, z)
     k*w1*w2*pk
 end
 

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -39,7 +39,9 @@ WeakLensingTracer(cosmo::Cosmology, z_n, nz) = begin
 
     # Calculate integral at each chi
     w_itg(zz, chii) = nz_int(zz)*(1-chii/cosmo.chi(zz))
-    w_arr = [quadgk(zz -> w_itg(zz, chi[i]), z_w[i], z_n[end])[1]
+    # OPT: use simpsons/trapz?
+    w_arr = [quadgk(zz -> w_itg(zz, chi[i]), z_w[i], z_n[end],
+                    rtol=1E-4)[1]
              for i=1:nchi]
     # Normalize
     H0 = cosmo.cosmo.h/CLIGHT_HMPC

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -26,6 +26,7 @@ end
 WeakLensingTracer(cosmo::Cosmology, z_n, nz) = begin
     # N(z) normalization
     nz_norm = trapz(z_n, nz)
+    nz_int = LinearInterpolation(z_n, nz, extrapolation_bc=0)
 
     # Calculate chis at which to precalculate the lensing kernel
     # OPT: perhaps we don't need to sample the lensing kernel

--- a/src/tracers.jl
+++ b/src/tracers.jl
@@ -9,8 +9,7 @@ end
 NumberCountsTracer(cosmo::Cosmology, z_n, nz, bias) = begin
     # OPT: here we only integrate to calculate the area.
     #      perhaps it'd be best to just use Simpsons.
-    nz_int = LinearInterpolation(z_n, nz, extrapolation_bc=0)
-    nz_norm = quadgk(nz_int, z_n[1], z_n[end], rtol=1E-5)[1]
+    nz_norm = trapz(z_n, nz)
     chi = cosmo.chi(z_n)
     hz = Hmpc(cosmo, z_n)
     w_arr = @. (nz*hz/nz_norm)
@@ -26,8 +25,7 @@ end
 
 WeakLensingTracer(cosmo::Cosmology, z_n, nz) = begin
     # N(z) normalization
-    nz_int = LinearInterpolation(z_n, nz, extrapolation_bc=0)
-    nz_norm = quadgk(nz_int, z_n[1], z_n[end], rtol=1E-5)[1]
+    nz_norm = trapz(z_n, nz)
 
     # Calculate chis at which to precalculate the lensing kernel
     # OPT: perhaps we don't need to sample the lensing kernel

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,7 +102,7 @@ using ForwardDiff
     @testset "EisHu_Cℓs" begin
         cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81,
                           nk=512, tk_mode="EisHu")
-        z = range(0., stop=2., length=1024)
+        z = range(0., stop=2., length=256)
         nz = @. exp(-0.5*((z-0.5)/0.05)^2)
         tg = NumberCountsTracer(cosmo, z, nz, 2.)
         ts = WeakLensingTracer(cosmo, z, nz)
@@ -124,18 +124,18 @@ using ForwardDiff
         Cℓ_sk_bm = [3.21788793e-08, 1.61961883e-08,
                      3.50133537e-09, 4.54239420e-10]
         # It'd be best if this was < 1E-4...
-        @test all(@. (abs(Cℓ_gg/Cℓ_gg_bm-1.0) < 5E-4))
-        @test all(@. (abs(Cℓ_gs/Cℓ_gs_bm-1.0) < 5E-4))
-        @test all(@. (abs(Cℓ_ss/Cℓ_ss_bm-1.0) < 5E-4))
-        @test all(@. (abs(Cℓ_gk/Cℓ_gk_bm-1.0) < 5E-4))
+        @test all(@. (abs(Cℓ_gg/Cℓ_gg_bm-1.0) < 5E-3))
+        @test all(@. (abs(Cℓ_gs/Cℓ_gs_bm-1.0) < 5E-3))
+        @test all(@. (abs(Cℓ_ss/Cℓ_ss_bm-1.0) < 5E-3))
+        @test all(@. (abs(Cℓ_gk/Cℓ_gk_bm-1.0) < 5E-3))
         # The ℓ=10 point is a bit inaccurate for some reason
         @test all(@. (abs(Cℓ_sk/Cℓ_sk_bm-1.0) < 3E-3))
     end
     
     @testset "Halo_Cℓs" begin
-        cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81, nk=10000, 
+        cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81,
                           tk_mode="EisHu", Pk_mode="Halofit")
-        z = range(0., stop=2., length=1024)
+        z = range(0., stop=2., length=256)
         nz = @. exp(-0.5*((z-0.5)/0.05)^2)
         tg = NumberCountsTracer(cosmo, z, nz, 2.)
         ts = WeakLensingTracer(cosmo, z, nz)
@@ -152,10 +152,10 @@ using ForwardDiff
         Cℓ_gk_bm = [1.31077487e-06, 1.42425553e-06, 5.19243548e-07, 1.01852050e-07]
         Cℓ_sk_bm = [3.18928412e-08, 1.61941343e-08, 3.99846079e-09, 9.53760295e-10]
         # It'd be best if this was < 1E-4...
-        @test all(@. (abs(Cℓ_gg/Cℓ_gg_bm-1.0) < 5E-4))
-        @test all(@. (abs(Cℓ_gs/Cℓ_gs_bm-1.0) < 5E-4))
-        @test all(@. (abs(Cℓ_ss/Cℓ_ss_bm-1.0) < 5E-4))
-        @test all(@. (abs(Cℓ_gk/Cℓ_gk_bm-1.0) < 5E-4))
+        @test all(@. (abs(Cℓ_gg/Cℓ_gg_bm-1.0) < 5E-3))
+        @test all(@. (abs(Cℓ_gs/Cℓ_gs_bm-1.0) < 5E-3))
+        @test all(@. (abs(Cℓ_ss/Cℓ_ss_bm-1.0) < 5E-3))
+        @test all(@. (abs(Cℓ_gk/Cℓ_gk_bm-1.0) < 5E-3))
         @test all(@. (abs(Cℓ_sk/Cℓ_sk_bm-1.0) < 1E-2))
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,9 +247,9 @@ using ForwardDiff
         Cl_sk_autodiff = ForwardDiff.derivative(Cl_sk, Ωm0)
         Cl_sk_anal = (Cl_sk(Ωm0+dΩm)-Cl_sk(Ωm0-dΩm))/2dΩm
 
-        @test all(@. (abs(Cl_gg_autodiff/Cl_gg_anal-1) < 3E-3))
-        @test all(@. (abs(Cl_ss_autodiff/Cl_ss_anal-1) < 1E-3))
-        @test all(@. (abs(Cl_sk_autodiff/Cl_sk_anal-1) < 1E-3))
+        @test all(@. (abs(Cl_gg_autodiff/Cl_gg_anal-1) < 1E-2))
+        @test all(@. (abs(Cl_ss_autodiff/Cl_ss_anal-1) < 1E-2))
+        @test all(@. (abs(Cl_sk_autodiff/Cl_sk_anal-1) < 1E-2))
     end
     
     @testset "IsHalofitDiff" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,9 @@ using ForwardDiff
     end
 
     @testset "PkBBKS" begin
-        cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81,
-                          nk=10000)
+        cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81)
         ks = [0.001, 0.01, 0.1, 1.0, 10.0]
-        pk = cosmo.Pk(ks, 0.)
+        pk = nonlin_Pk(cosmo, ks, 0.0)
         pk_bm = [2.01570296e+04,
                  7.77178497e+04,
                  1.04422728e+04,
@@ -42,9 +41,9 @@ using ForwardDiff
 
     @testset "PkEisHu" begin
         cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81,
-                          nk=10000, tk_mode="EisHu")
+                          nk=768, tk_mode="EisHu")
         ks = [0.001, 0.01, 0.1, 1.0, 10.0]
-        pk = cosmo.Pk(ks, 0.)
+        pk = nonlin_Pk(cosmo, ks, 0.0)
         pk_bm = [2.12222992e+04,
                  8.83444294e+04,
                  1.05452648e+04,
@@ -56,22 +55,21 @@ using ForwardDiff
 
     @testset "PkHalofit" begin
         cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81,
-                          nk=10000, tk_mode="EisHu", 
+                          nk=512, tk_mode="EisHu", 
                           Pk_mode="Halofit")
         ks = [0.001, 0.01, 0.1, 1.0, 10.0]
-        pk = LimberJack.nonlin_Pk(cosmo, ks, 0)
+        pk = nonlin_Pk(cosmo, ks, 0)
         pk_bm = [2.12015208e+04,
                  8.75109090e+04,
                  1.15273287e+04,
                  8.52170268e+02,
                  1.31682588e+01]
         # It'd be best if this was < 1E-4...
-        @test all(@. (abs(pk/pk_bm-1.0) < 3E-3))
+        @test all(@. (abs(pk/pk_bm-1.0) < 3E-4))
     end
     
     @testset "BBKS_Cℓs" begin
-        cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81,
-                          nk=10000)
+        cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81)
         z = range(0., stop=2., length=1024)
         nz = @. exp(-0.5*((z-0.5)/0.05)^2)
         tg = NumberCountsTracer(cosmo, z, nz, 2.)
@@ -103,7 +101,7 @@ using ForwardDiff
 
     @testset "EisHu_Cℓs" begin
         cosmo = Cosmology(0.30, 0.05, 0.67, 0.96, 0.81,
-                          nk=10000, tk_mode="EisHu")
+                          nk=512, tk_mode="EisHu")
         z = range(0., stop=2., length=1024)
         nz = @. exp(-0.5*((z-0.5)/0.05)^2)
         tg = NumberCountsTracer(cosmo, z, nz, 2.)
@@ -130,7 +128,8 @@ using ForwardDiff
         @test all(@. (abs(Cℓ_gs/Cℓ_gs_bm-1.0) < 5E-4))
         @test all(@. (abs(Cℓ_ss/Cℓ_ss_bm-1.0) < 5E-4))
         @test all(@. (abs(Cℓ_gk/Cℓ_gk_bm-1.0) < 5E-4))
-        @test all(@. (abs(Cℓ_sk/Cℓ_sk_bm-1.0) < 1E-2))
+        # The ℓ=10 point is a bit inaccurate for some reason
+        @test all(@. (abs(Cℓ_sk/Cℓ_sk_bm-1.0) < 3E-3))
     end
 
     @testset "CreateTracer" begin
@@ -179,14 +178,14 @@ using ForwardDiff
         function BBKS(p::T)::Array{T,1} where T<:Real
             Ωm = p
             cosmo = LimberJack.Cosmology(Ωm, 0.05, 0.67, 0.96, 0.81)
-            pk = cosmo.Pk(ks, 0.)
+            pk = lin_Pk(cosmo, ks, 0.)
             return pk
         end
 
         function EisHu(p::T)::Array{T,1} where T<:Real
             Ωm = p
             cosmo = LimberJack.Cosmology(Ωm, 0.05, 0.67, 0.96, 0.81, tk_mode="EisHu")
-            pk = cosmo.Pk(ks, 0.)
+            pk = lin_Pk(cosmo, ks, 0.)
             return pk
         end
 
@@ -207,7 +206,7 @@ using ForwardDiff
         function Cl_gg(p::T)::Array{T,1} where T<:Real
             Ωm = p
             cosmo = LimberJack.Cosmology(Ωm, 0.05, 0.67, 0.96, 0.81)
-            z = range(0., stop=2., length=1024)
+            z = range(0., stop=2., length=256)
             nz = @. exp(-0.5*((z-0.5)/0.05)^2)
             tg = NumberCountsTracer(cosmo, z, nz, 2.)
             ℓs = [10, 30, 100, 300]
@@ -218,7 +217,7 @@ using ForwardDiff
         function Cl_ss(p::T)::Array{T,1} where T<:Real
             Ωm = p
             cosmo = LimberJack.Cosmology(Ωm, 0.05, 0.67, 0.96, 0.81)
-            z = range(0., stop=2., length=1024)
+            z = range(0., stop=2., length=256)
             nz = @. exp(-0.5*((z-0.5)/0.05)^2)
             ts = WeakLensingTracer(cosmo, z, nz)
             ℓs = [10, 30, 100, 300]
@@ -229,7 +228,7 @@ using ForwardDiff
         function Cl_sk(p::T)::Array{T,1} where T<:Real
             Ωm = p
             cosmo = LimberJack.Cosmology(Ωm, 0.05, 0.67, 0.96, 0.81)
-            z = range(0., stop=2., length=1024)
+            z = range(0., stop=2., length=256)
             nz = @. exp(-0.5*((z-0.5)/0.05)^2)
             ts = WeakLensingTracer(cosmo, z, nz)
             tk = CMBLensingTracer(cosmo)
@@ -239,7 +238,7 @@ using ForwardDiff
         end
 
         Ωm0 = 0.3
-        dΩm = 0.001
+        dΩm = 0.01
 
         Cl_gg_autodiff = ForwardDiff.derivative(Cl_gg, Ωm0)
         Cl_gg_anal = (Cl_gg(Ωm0+dΩm)-Cl_gg(Ωm0-dΩm))/2dΩm
@@ -248,9 +247,9 @@ using ForwardDiff
         Cl_sk_autodiff = ForwardDiff.derivative(Cl_sk, Ωm0)
         Cl_sk_anal = (Cl_sk(Ωm0+dΩm)-Cl_sk(Ωm0-dΩm))/2dΩm
 
-        @test all(@. (abs(Cl_gg_autodiff/Cl_gg_anal-1) < 2E-2))
-        @test all(@. (abs(Cl_ss_autodiff/Cl_ss_anal-1) < 2E-3))
-        @test all(@. (abs(Cl_sk_autodiff/Cl_sk_anal-1) < 2E-2))
+        @test all(@. (abs(Cl_gg_autodiff/Cl_gg_anal-1) < 3E-3))
+        @test all(@. (abs(Cl_ss_autodiff/Cl_ss_anal-1) < 1E-3))
+        @test all(@. (abs(Cl_sk_autodiff/Cl_sk_anal-1) < 1E-3))
     end
     
     @testset "IsHalofitDiff" begin


### PR DESCRIPTION
Changes to halofit to make it faster and differentiable.

Two main things:
- Removed unnecessary arrays
- Root finding was using integrals within function. Splined instead.
- `find_zero` was not differentiable for some reason. Replaced with simple secant method.